### PR TITLE
Optional and adjustable API token

### DIFF
--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -72,7 +72,7 @@ final public class OpenAI: OpenAIProtocol {
     private let session: URLSessionProtocol
     private var streamingSessions = ArrayWithThreadSafety<NSObject>()
     
-    public let configuration: Configuration
+    public var configuration: Configuration
 
     public convenience init(apiToken: String) {
         self.init(configuration: Configuration(token: apiToken), session: URLSession.shared)

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -16,15 +16,17 @@ final public class OpenAI: OpenAIProtocol {
     public struct Configuration {
         
         /// OpenAI API token. See https://platform.openai.com/docs/api-reference/authentication
-        public let token: String
+        public var token: String?
         
         /// Optional OpenAI organization identifier. See https://platform.openai.com/docs/api-reference/authentication
         public let organizationIdentifier: String?
         
         /// API host. Set this property if you use some kind of proxy or your own server. Default is api.openai.com
         public let host: String
+        
         /// API port. Set this property if you use some kind of proxy or your own server. Default is 443
         public let port: Int
+        
         /// API scheme. Set this property if you use some kind of proxy or your own server. Default is 443
         public let scheme: String
         
@@ -47,7 +49,7 @@ final public class OpenAI: OpenAIProtocol {
         ///    - caCertificate: Optional custom CA certificate that should be used for the TLS verification. Useful if using a custom root CA certificate to sign the API host.
         ///    - expectedHost: Optional expected hostname to verify the received TLS token against. Useful for network requests to another domain or IP than the host issued the TLS token.
         public init(
-            token: String,
+            token: String?,
             organizationIdentifier: String? = nil,
             host: String = "api.openai.com",
             port: Int = 443,

--- a/Sources/OpenAI/Private/JSONRequest.swift
+++ b/Sources/OpenAI/Private/JSONRequest.swift
@@ -25,10 +25,12 @@ final class JSONRequest<ResultType> {
 
 extension JSONRequest: URLRequestBuildable {
     
-    func build(token: String, organizationIdentifier: String?, timeoutInterval: TimeInterval, expectedHost: String? = nil) throws -> URLRequest {
+    func build(token: String?, organizationIdentifier: String?, timeoutInterval: TimeInterval, expectedHost: String? = nil) throws -> URLRequest {
         var request = URLRequest(url: url, timeoutInterval: timeoutInterval)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        if let token {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
         if let organizationIdentifier {
             request.setValue(organizationIdentifier, forHTTPHeaderField: "OpenAI-Organization")
         }

--- a/Sources/OpenAI/Private/MultipartFormDataRequest.swift
+++ b/Sources/OpenAI/Private/MultipartFormDataRequest.swift
@@ -25,12 +25,14 @@ final class MultipartFormDataRequest<ResultType> {
 
 extension MultipartFormDataRequest: URLRequestBuildable {
     
-    func build(token: String, organizationIdentifier: String?, timeoutInterval: TimeInterval, expectedHost: String? = nil) throws -> URLRequest {
+    func build(token: String?, organizationIdentifier: String?, timeoutInterval: TimeInterval, expectedHost: String? = nil) throws -> URLRequest {
         var request = URLRequest(url: url)
         let boundary: String = UUID().uuidString
         request.timeoutInterval = timeoutInterval
         request.httpMethod = method
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        if let token {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         if let organizationIdentifier {
             request.setValue(organizationIdentifier, forHTTPHeaderField: "OpenAI-Organization")

--- a/Sources/OpenAI/Private/StreamingSession.swift
+++ b/Sources/OpenAI/Private/StreamingSession.swift
@@ -133,7 +133,7 @@ final class StreamingSession<ResultType: Codable>: NSObject, Identifiable, URLSe
             completionHandler(.useCredential, URLCredential(trust: serverTrust))
         } else {
             // Trust evaluation failed, handle the error
-            print("OpenAI: Trust evaluation failed with error: \(error?.localizedDescription)")
+            print("OpenAI: Trust evaluation failed with error: \(String(describing: error?.localizedDescription))")
             completionHandler(.cancelAuthenticationChallenge, nil)
         }
     }

--- a/Sources/OpenAI/Private/URLRequestBuildable.swift
+++ b/Sources/OpenAI/Private/URLRequestBuildable.swift
@@ -14,5 +14,5 @@ protocol URLRequestBuildable {
     
     associatedtype ResultType
     
-    func build(token: String, organizationIdentifier: String?, timeoutInterval: TimeInterval, expectedHost: String?) throws -> URLRequest
+    func build(token: String?, organizationIdentifier: String?, timeoutInterval: TimeInterval, expectedHost: String?) throws -> URLRequest
 }


### PR DESCRIPTION
# Optional and adjustable API token

## :recycle: Current situation & Problem
As of now, the API token is required and fixed after the initial initialization of the `OpenAI` struct. This leads to challenges, especially with OpenAI API implementations (such as Ollama) that don't require an API token or need to refresh API tokens from time to time.


## :gear: Release Notes 
- Optional and adjustable API token in the init of `OpenAI`.


## :books: Documentation
--


## :white_check_mark: Testing
Manually tested.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
